### PR TITLE
Stop occasionally making file systems with null UUIDs

### DIFF
--- a/libreiser4/master.c
+++ b/libreiser4/master.c
@@ -295,8 +295,8 @@ void reiser4_master_set_uuid(reiser4_master_t *master,
 		   sizeof(SUPER(master)->ms_uuid));
 	
 	if (uuid) {
-		aal_strncpy(SUPER(master)->ms_uuid, uuid,
-			    sizeof(SUPER(master)->ms_uuid));
+		aal_memcpy(SUPER(master)->ms_uuid, uuid,
+			   sizeof(SUPER(master)->ms_uuid));
 	} 
 	master->dirty = 1;
 }


### PR DESCRIPTION
mkfs.reiser4 was using strncpy() to copy a binary UUID into the
in-memory copy of the superblock.  So if there was a zero byte in the
UUID, then from that point to the end was set to all zeros.  If the
first byte was zero, a 1 in 256 chance, then the whole UUID was set to
zero generating a null UUID for the file system.

Here's the fix for this.

Thanks,
Mike